### PR TITLE
client_max_body_size 100m; (or die)

### DIFF
--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -25,6 +25,13 @@ http {
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
 
+  ##
+  # Upload
+  ##
+  # Many apps will complain if they can't receive more than the default "1m".
+  # This limit is aligned with bearstech/php's runtime limits.
+  client_max_body_size 100m;
+
 	##
 	# SSL Settings
 	##


### PR DESCRIPTION
Required for https://github.com/factorysh/docker-php/pull/10 to make sense.

Otherwise upload of the nginx -> php-fpm stack is 1M max.
